### PR TITLE
Fix key error: e_map has no key 'OTHER'

### DIFF
--- a/mimic3benchmark/preprocessing.py
+++ b/mimic3benchmark/preprocessing.py
@@ -43,7 +43,7 @@ def transform_ethnicity(ethnicity_series):
         return ethnicity_str.replace(' OR ', '/').split(' - ')[0].split('/')[0]
 
     ethnicity_series = ethnicity_series.apply(aggregate_ethnicity)
-    return {'Ethnicity': ethnicity_series.fillna('').apply(lambda s: e_map[s] if s in e_map else e_map['OTHER'])}
+    return {'Ethnicity': ethnicity_series.fillna('').apply(lambda s: e_map[s] if s in e_map else e_map['UNKNOWN'])}
 
 
 def assemble_episodic_data(stays, diagnoses):

--- a/mimic3benchmark/preprocessing.py
+++ b/mimic3benchmark/preprocessing.py
@@ -33,6 +33,7 @@ e_map = {'ASIAN': 1,
          'UNABLE TO OBTAIN': 0,
          'PATIENT DECLINED TO ANSWER': 0,
          'UNKNOWN': 0,
+         'OTHER': 0,
          '': 0}
 
 
@@ -43,7 +44,7 @@ def transform_ethnicity(ethnicity_series):
         return ethnicity_str.replace(' OR ', '/').split(' - ')[0].split('/')[0]
 
     ethnicity_series = ethnicity_series.apply(aggregate_ethnicity)
-    return {'Ethnicity': ethnicity_series.fillna('').apply(lambda s: e_map[s] if s in e_map else e_map['UNKNOWN'])}
+    return {'Ethnicity': ethnicity_series.fillna('').apply(lambda s: e_map[s] if s in e_map else e_map['OTHER'])}
 
 
 def assemble_episodic_data(stays, diagnoses):


### PR DESCRIPTION
Quick fix for key error in preprocessing.py
ethnicity map e_map has no key 'OTHER' (only g_map has it), and it causes error during the step 4 of building benchmark.
Therefore, I changed it to 'UNKNOWN'.
I would appreciate it if you could review this PR.