### PR TITLE
Use iloc and rename instead of ix and reanme_axis

### DIFF
--- a/mimic3benchmark/scripts/extract_episodes_from_subjects.py
+++ b/mimic3benchmark/scripts/extract_episodes_from_subjects.py
@@ -78,9 +78,9 @@ for subject_dir in os.listdir(args.subjects_root_path):
             continue
 
         episode = add_hours_elpased_to_events(episode, intime).set_index('HOURS').sort_index(axis=0)
-        episodic_data.Weight.ix[stay_id] = get_first_valid_from_timeseries(episode, 'Weight')
-        episodic_data.Height.ix[stay_id] = get_first_valid_from_timeseries(episode, 'Height')
-        episodic_data.ix[episodic_data.index==stay_id].to_csv(os.path.join(args.subjects_root_path, subject_dir, 'episode{}.csv'.format(i+1)), index_label='Icustay')
+        episodic_data.Weight.iloc[stay_id] = get_first_valid_from_timeseries(episode, 'Weight')
+        episodic_data.Height.iloc[stay_id] = get_first_valid_from_timeseries(episode, 'Height')
+        episodic_data.iloc[episodic_data.index==stay_id].to_csv(os.path.join(args.subjects_root_path, subject_dir, 'episode{}.csv'.format(i+1)), index_label='Icustay')
         columns = list(episode.columns)
         columns_sorted = sorted(columns, key=(lambda x: "" if x == "Hours" else x))
         episode = episode[columns_sorted]

--- a/mimic3benchmark/subject.py
+++ b/mimic3benchmark/subject.py
@@ -26,7 +26,7 @@ def read_diagnoses(subject_path):
 def read_events(subject_path, remove_null=True):
     events = dataframe_from_csv(os.path.join(subject_path, 'events.csv'), index_col=None)
     if remove_null:
-        events = events.ix[events.VALUE.notnull()]
+        events = events.iloc[events.VALUE.notnull()]
     events.CHARTTIME = pd.to_datetime(events.CHARTTIME)
     events.HADM_ID = events.HADM_ID.fillna(value=-1).astype(int)
     events.ICUSTAY_ID = events.ICUSTAY_ID.fillna(value=-1).astype(int)
@@ -39,7 +39,7 @@ def get_events_for_stay(events, icustayid, intime=None, outtime=None):
     idx = (events.ICUSTAY_ID == icustayid)
     if intime is not None and outtime is not None:
         idx = idx | ((events.CHARTTIME >= intime) & (events.CHARTTIME <= outtime))
-    events = events.ix[idx]
+    events = events.iloc[idx]
     del events['ICUSTAY_ID']
     return events
 


### PR DESCRIPTION
Replace deprecated interfaces in pandas by substiuting .iloc to index
instead of .ix and replace .rename(columns=...) instead of
.rename_axis(axis=1,...).

Fixed a couple of issues causing runtime errors with pandas 0.25.3 and
python 3.7.