### PR TITLE
Support for newer versions of libraries

### DIFF
--- a/mimic3benchmark/mimic3csv.py
+++ b/mimic3benchmark/mimic3csv.py
@@ -76,7 +76,7 @@ def merge_on_subject_admission(table1, table2):
 
 
 def add_age_to_icustays(stays):
-    stays['AGE'] = (stays.INTIME - stays.DOB).apply(lambda s: s / np.timedelta64(1, 's')) / 60./60/24/365
+    stays['AGE'] = stays.apply(lambda e: (e['INTIME'].to_pydatetime() - e['DOB'].to_pydatetime()).days / 365.25, axis=1)
     stays.loc[stays.AGE < 0, 'AGE'] = 90
     return stays
 

--- a/mimic3benchmark/scripts/create_multitask.py
+++ b/mimic3benchmark/scripts/create_multitask.py
@@ -206,7 +206,7 @@ def main():
     args, _ = parser.parse_known_args()
 
     with open(args.phenotype_definitions) as definitions_file:
-        definitions = yaml.load(definitions_file)
+        definitions = yaml.safe_load(definitions_file)
 
     code_to_group = {}
     for group in definitions:

--- a/mimic3benchmark/scripts/create_phenotyping.py
+++ b/mimic3benchmark/scripts/create_phenotyping.py
@@ -100,7 +100,7 @@ def main():
     args, _ = parser.parse_known_args()
 
     with open(args.phenotype_definitions) as definitions_file:
-        definitions = yaml.load(definitions_file)
+        definitions = yaml.safe_load(definitions_file)
 
     code_to_group = {}
     for group in definitions:

--- a/mimic3benchmark/scripts/extract_subjects.py
+++ b/mimic3benchmark/scripts/extract_subjects.py
@@ -61,7 +61,7 @@ diagnoses = filter_diagnoses_on_stays(diagnoses, stays)
 diagnoses.to_csv(os.path.join(args.output_path, 'all_diagnoses.csv'), index=False)
 count_icd_codes(diagnoses, output_path=os.path.join(args.output_path, 'diagnosis_counts.csv'))
 
-phenotypes = add_hcup_ccs_2015_groups(diagnoses, yaml.load(open(args.phenotype_definitions, 'r')))
+phenotypes = add_hcup_ccs_2015_groups(diagnoses, yaml.safe_load(open(args.phenotype_definitions, 'r')))
 make_phenotype_label_matrix(phenotypes, stays).to_csv(os.path.join(args.output_path, 'phenotype_labels.csv'),
                                                       index=False, quoting=csv.QUOTE_NONNUMERIC)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Keras==2.1.2
-numpy>=1.13.3
-scikit-learn==0.18.2
-pandas==0.23.4
+Keras
+numpy
+scikit-learn
+pandas
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Keras
-numpy==1.*
-scikit-learn==0.*
-pandas==1.*
-tqdm==4.*
-pyyaml==5.*
+Keras==2.1.2
+numpy>=1.13.3
+scikit-learn==0.18.2
+pandas==1.5.*
+tqdm
+pyyaml>=5.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Keras
-numpy
-scikit-learn
-pandas
-tqdm
+numpy==1.*
+scikit-learn==0.*
+pandas==1.*
+tqdm==4.*
+pyyaml==5.*


### PR DESCRIPTION
Recent versions of `pandas` and `pyyaml` break the preprocessing scripts. A few edits are needed to fix it.