### PR TITLE
Replace add safe Loader argument to yaml load (suppresing the warning message) "mimic3-benchmarks/mimic3benchmark/scripts/extract_subjects.py", …

### DIFF
--- a/mimic3benchmark/scripts/extract_subjects.py
+++ b/mimic3benchmark/scripts/extract_subjects.py
@@ -61,7 +61,7 @@ diagnoses = filter_diagnoses_on_stays(diagnoses, stays)
 diagnoses.to_csv(os.path.join(args.output_path, 'all_diagnoses.csv'), index=False)
 count_icd_codes(diagnoses, output_path=os.path.join(args.output_path, 'diagnosis_counts.csv'))
 
-phenotypes = add_hcup_ccs_2015_groups(diagnoses, yaml.load(open(args.phenotype_definitions, 'r')))
+phenotypes = add_hcup_ccs_2015_groups(diagnoses, yaml.load(open(args.phenotype_definitions, 'r'), Loader = yaml.SafeLoader))
 make_phenotype_label_matrix(phenotypes, stays).to_csv(os.path.join(args.output_path, 'phenotype_labels.csv'),
                                                       index=False, quoting=csv.QUOTE_NONNUMERIC)
 


### PR DESCRIPTION
There is the following warning in the first step of preprocessing: 
`
mimic3-benchmarks/mimic3benchmark/scripts/extract_subjects.py:64: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
`

The warning is there due to  arbitrary shell execution of the deprecated yaml.open .
 
Adding Loader = yaml.SafeLoader suppreses the warning. I checked that the yaml file we use if for (HCUP complex disease definition) does not have any special character and is parsed safely. 
