### PR TITLE
fix: pandas 2.x compatibility — rename, inplace, axis deprecations

### DIFF
--- a/mimic3benchmark/preprocessing.py
+++ b/mimic3benchmark/preprocessing.py
@@ -98,7 +98,7 @@ def make_phenotype_label_matrix(phenotypes, stays=None):
     phenotypes = phenotypes.pivot(index='ICUSTAY_ID', columns='HCUP_CCS_2015', values='VALUE')
     if stays is not None:
         phenotypes = phenotypes.reindex(stays.ICUSTAY_ID.sort_values())
-    return phenotypes.fillna(0).astype(int).sort_index(axis=0).sort_index(axis=1)
+    return phenotypes.fillna(0).astype(int).sort_index().sort_index(axis=1)
 
 
 ###################################
@@ -113,7 +113,7 @@ def read_itemid_to_variable_map(fn, variable_column='LEVEL2'):
     var_map = var_map[(var_map.STATUS == 'ready')]
     var_map.ITEMID = var_map.ITEMID.astype(int)
     var_map = var_map[[variable_column, 'ITEMID', 'MIMIC LABEL']].set_index('ITEMID')
-    return var_map.rename({variable_column: 'VARIABLE', 'MIMIC LABEL': 'MIMIC_LABEL'}, axis=1)
+    return var_map.rename(columns={variable_column: 'VARIABLE', 'MIMIC LABEL': 'MIMIC_LABEL'})
 
 
 def map_itemids_to_variables(events, var_map):
@@ -127,9 +127,9 @@ def read_variable_ranges(fn, variable_column='LEVEL2'):
     var_ranges = dataframe_from_csv(fn, index_col=None)
     # var_ranges = var_ranges[variable_column].apply(lambda s: s.lower())
     var_ranges = var_ranges[columns]
-    var_ranges.rename(to_rename, axis=1, inplace=True)
+    var_ranges = var_ranges.rename(columns=to_rename)
     var_ranges = var_ranges.drop_duplicates(subset='VARIABLE', keep='first')
-    var_ranges.set_index('VARIABLE', inplace=True)
+    var_ranges = var_ranges.set_index('VARIABLE')
     return var_ranges.loc[var_ranges.notnull().all(axis=1)]
 
 

--- a/mimic3benchmark/scripts/extract_episodes_from_subjects.py
+++ b/mimic3benchmark/scripts/extract_episodes_from_subjects.py
@@ -62,7 +62,7 @@ for subject_dir in tqdm(os.listdir(args.subjects_root_path), desc='Iterating ove
             # no data for this episode
             continue
 
-        episode = add_hours_elpased_to_events(episode, intime).set_index('HOURS').sort_index(axis=0)
+        episode = add_hours_elpased_to_events(episode, intime).set_index('HOURS').sort_index()
         if stay_id in episodic_data.index:
             episodic_data.loc[stay_id, 'Weight'] = get_first_valid_from_timeseries(episode, 'Weight')
             episodic_data.loc[stay_id, 'Height'] = get_first_valid_from_timeseries(episode, 'Height')

--- a/mimic3benchmark/subject.py
+++ b/mimic3benchmark/subject.py
@@ -12,7 +12,7 @@ def read_stays(subject_path):
     stays.DOB = pd.to_datetime(stays.DOB)
     stays.DOD = pd.to_datetime(stays.DOD)
     stays.DEATHTIME = pd.to_datetime(stays.DEATHTIME)
-    stays.sort_values(by=['INTIME', 'OUTTIME'], inplace=True)
+    stays = stays.sort_values(by=['INTIME', 'OUTTIME'])
     return stays
 
 
@@ -53,11 +53,11 @@ def convert_events_to_timeseries(events, variable_column='VARIABLE', variables=[
     metadata = events[['CHARTTIME', 'ICUSTAY_ID']].sort_values(by=['CHARTTIME', 'ICUSTAY_ID'])\
                     .drop_duplicates(keep='first').set_index('CHARTTIME')
     timeseries = events[['CHARTTIME', variable_column, 'VALUE']]\
-                    .sort_values(by=['CHARTTIME', variable_column, 'VALUE'], axis=0)\
+                    .sort_values(by=['CHARTTIME', variable_column, 'VALUE'])\
                     .drop_duplicates(subset=['CHARTTIME', variable_column], keep='last')
     timeseries = timeseries.pivot(index='CHARTTIME', columns=variable_column, values='VALUE')\
                     .merge(metadata, left_index=True, right_index=True)\
-                    .sort_index(axis=0).reset_index()
+                    .sort_index().reset_index()
     for v in variables:
         if v not in timeseries:
             timeseries[v] = np.nan


### PR DESCRIPTION
## Summary

The codebase fails with pandas 2.0+ due to deprecated APIs. This PR fixes 8 issues across 3 files.

### Fixes

| File | Line | Issue | Fix |
|------|------|-------|-----|
| `preprocessing.py` | 116 | `.rename(dict, axis=1)` raises ValueError | `.rename(columns=dict)` |
| `preprocessing.py` | 130 | `inplace=True` deprecated | Assignment pattern |
| `preprocessing.py` | 132 | `set_index(..., inplace=True)` deprecated | Assignment pattern |
| `preprocessing.py` | 101 | `sort_index(axis=0)` explicit axis deprecated | `sort_index()` |
| `subject.py` | 15 | `sort_values(..., inplace=True)` deprecated | Assignment pattern |
| `subject.py` | 56 | `sort_values(axis=0)` deprecated | Remove axis param |
| `subject.py` | 60 | `sort_index(axis=0)` deprecated | Remove axis param |
| `extract_episodes_from_subjects.py` | 65 | `sort_index(axis=0)` deprecated | Remove axis param |

All changes are backward compatible with pandas 1.x.

Fixes #138